### PR TITLE
docs: production-hardened review loops & external-agent safety

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -9,6 +9,7 @@ Production-tested Claude Code configuration patterns extracted from hip-phoenix.
 ## Key Files
 
 - **setup.md** - Per-repo Claude Code configuration (hooks, skills, slash commands, dev docs, review loops)
+- **review-loops.md** - Production-hardened review loops (Codex-primary/Opus-fallback reviewers, the `MATERIAL_FINDINGS` contract, three review passes, `codex-safe.sh` secret-stripping, subagent scope hygiene)
 - **laptop-setup.md** - One-time machine setup (worktrees, keyboard shortcuts)
 - **README.md** - Public-facing description of the repository
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,6 +10,7 @@ Production-tested Claude Code configuration patterns extracted from hip-phoenix.
 
 - **setup.md** - Per-repo Claude Code configuration (hooks, skills, slash commands, dev docs, review loops)
 - **review-loops.md** - Production-hardened review loops (Codex-primary/Opus-fallback reviewers, the `MATERIAL_FINDINGS` contract, three review passes, `codex-safe.sh` secret-stripping, subagent scope hygiene)
+- **sdlc-standards.md** - Repo-level engineering invariants an agent must respect (generated-file discipline, migration-as-deploy-gate, nightly→release gating, preview-env smoke tests, fail-fast env validation)
 - **laptop-setup.md** - One-time machine setup (worktrees, keyboard shortcuts)
 - **README.md** - Public-facing description of the repository
 

--- a/README.md
+++ b/README.md
@@ -21,6 +21,17 @@ The main document. Covers everything you need to add Claude Code to a project:
 - **CLAUDE.md patterns** — PR template enforcement, permissions allow-list, review loops
 - **Context window management** — MCP guidelines, subagent patterns
 
+### [review-loops.md](review-loops.md) — Automated review loops & external-agent safety
+
+What the review loops in `setup.md` look like after months in production:
+
+- **Codex-primary, Opus-fallback reviewers** — pin the external reviewer's model explicitly, fall back to an in-model review on credit exhaustion/auth failure/format-less output so the loop never silently stalls
+- **The `MATERIAL_FINDINGS` convergence contract** — severity-gated stop condition the wrapper agent can't re-litigate
+- **Three review passes** — plan (before code), code (`base master`, not `uncommitted`), and post-PR (what a human reviewer sees on GitHub)
+- **`codex-safe.sh`** — strip `DATABASE_URL`/`AUTH_SECRET`/API keys from the env before shelling out to an external agent
+- **Subagent scope hygiene** — the skip-list that stops review/explore subagents from burning their budget on `node_modules`
+- **Stop-hook gates** — derived-doc drift and live integration-test gates that catch what diff-only reviewers miss
+
 ### [laptop-setup.md](laptop-setup.md) — One-time machine setup
 
 Run once per laptop:

--- a/README.md
+++ b/README.md
@@ -32,6 +32,16 @@ What the review loops in `setup.md` look like after months in production:
 - **Subagent scope hygiene & model-tiering** — the skip-list that stops review/explore subagents from burning budget on `node_modules`, plus matching the model tier to the work: Haiku for the high-volume retrieval phase (read the diff, grep callers, gather context), Opus only for the verdict
 - **Stop-hook gates** — derived-doc drift and live integration-test gates that catch what diff-only reviewers miss
 
+### [sdlc-standards.md](sdlc-standards.md) — Repo-level standards an agent must respect
+
+Engineering invariants worth porting to any repo — the ones that produce confident-but-wrong agent edits when missing:
+
+- **Generated-file discipline** — one editable source → N generated outputs, each with a `DO NOT EDIT` header, a guardrail skill, and a CI drift check (TypeSpec → models; shared JSON → TS + Python)
+- **The migration *is* the deploy gate** — the load-bearing `context:` status string, trigger-coverage gaps that look like "the migration broke," and never `db:push` against deployed envs
+- **Validation decoupled from deployment** — gate the release on a scheduled nightly, with a bypass that demands and records a justification
+- **Preview-env smoke tests** — require `curl`-against-a-real-deploy evidence for REST/MCP/OAuth/webhook changes, in the PR template
+- **Fail fast at `predev`** — env validation + a `doctor` command so a broken environment is a named error, not a runtime crash
+
 ### [laptop-setup.md](laptop-setup.md) — One-time machine setup
 
 Run once per laptop:

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ What the review loops in `setup.md` look like after months in production:
 - **The `MATERIAL_FINDINGS` convergence contract** — severity-gated stop condition the wrapper agent can't re-litigate
 - **Three review passes** — plan (before code), code (`base master`, not `uncommitted`), and post-PR (what a human reviewer sees on GitHub)
 - **`codex-safe.sh`** — strip `DATABASE_URL`/`AUTH_SECRET`/API keys from the env before shelling out to an external agent
-- **Subagent scope hygiene** — the skip-list that stops review/explore subagents from burning their budget on `node_modules`
+- **Subagent scope hygiene & model-tiering** — the skip-list that stops review/explore subagents from burning budget on `node_modules`, plus matching the model tier to the work: Haiku for the high-volume retrieval phase (read the diff, grep callers, gather context), Opus only for the verdict
 - **Stop-hook gates** — derived-doc drift and live integration-test gates that catch what diff-only reviewers miss
 
 ### [laptop-setup.md](laptop-setup.md) — One-time machine setup

--- a/review-loops.md
+++ b/review-loops.md
@@ -1,0 +1,106 @@
+# Automated Review Loops & External-Agent Safety
+
+Patterns hardened in hip-phoenix *after* the original [setup.md](setup.md) was written. Where `setup.md` sketches generic plan/code review loops, this is what the production version actually looks like once you run it against a real codebase for a few months: a primary external reviewer (Codex) with an automatic in-model fallback, a strict convergence contract, three distinct review passes, and the safety + token-cost guardrails you discover only after they bite you.
+
+## 1. Reviewer subagents: external-primary, in-model fallback
+
+The review loops in `setup.md` assume a single reviewer. In practice you want the *strongest available* reviewer with a guarantee the loop never silently stalls. The hip-phoenix `plan-reviewer` and `code-reviewer` subagents both follow the same shape:
+
+**Step 1 — try the external reviewer (Codex).** Pin the model explicitly; never inherit CLI defaults from `~/.codex/config.toml`, because a teammate's local config should not change what your review loop does:
+
+```bash
+.claude/hooks/codex-safe.sh exec \
+  -m gpt-5.5 \
+  -c model_reasoning_effort=high \
+  review --base master --full-auto -o /tmp/review-out.md
+```
+
+**Step 2 — detect failure honestly.** Treat the external run as *failed* (and fall back) when ANY of these hold — not just on a non-zero exit code:
+
+- non-zero exit / CLI missing / auth or credit-exhaustion error
+- empty output file
+- the output does not contain the literal contract string `MATERIAL_FINDINGS`
+
+That last one matters: an external agent can "succeed" while reviewing the wrong target (e.g. a sandboxed GitHub plugin that can't reach the PR silently reviews a stale local branch and returns prose with no verdict). Treat format-less output as failure, not as a clean review.
+
+**Step 3 — fall back to the in-model reviewer (Opus).** Same input contract, same output format. The fallback reads the diff/plan directly (`gh pr diff`, `git diff --base`, `Read`), spot-checks the load-bearing claims against the actual code, and applies the same severity rubric. The point of the fallback is to **keep the loop running** when the external reviewer is down — never to report "reviewer unavailable" with an empty findings list.
+
+Every review — both paths — ends with a machine-parseable footer:
+
+```
+MATERIAL_FINDINGS: true|false
+REVIEWER: codex|claude-opus
+```
+
+The `REVIEWER:` line is mandatory in both paths so the parent agent (and you, reading the log) can tell which reviewer produced a finding without grepping logs.
+
+## 2. The convergence contract
+
+The loop's stop condition is severity-gated, and the gating is **not re-litigated** by the wrapper agent:
+
+- `MATERIAL_FINDINGS: true` iff at least one finding is `[critical] / [high] / [major]`.
+- `[minor] / [nit] / style` findings may be listed but never flip the gate on their own.
+- The parent agent does **not** re-classify or filter — any material finding from *either* reviewer (Codex or the Opus fallback) sets the gate. This is deliberate: it stops a wrapper from rationalizing away a real finding to escape the loop.
+
+Loop until `MATERIAL_FINDINGS: false` or a hard cap (10 rounds in hip-phoenix). Log every round — round number, reviewer, findings summary — in `context.md` so a resumed session knows where the loop stood.
+
+## 3. Three review passes, not one
+
+A single post-implementation review misses two whole classes of problem. hip-phoenix runs the loop at three points:
+
+| Pass | When | Scope argument | Catches |
+|------|------|----------------|---------|
+| **Plan review** | after writing `plan.md`, before any code | the plan file | wrong approach, missing migration step, unstated dependency — *before* you've written code against it |
+| **Code review** | after implementation, before commit | `base master` (matches the eventual PR diff — **not** `uncommitted`) | bugs, missing tests, convention drift |
+| **Post-PR review** | after the PR is opened | `pr <PR_URL>` | what a human reviewer actually sees on GitHub — rendered diff, CI context, cross-file interactions the local diff obscured |
+
+The plan pass is the highest-leverage one and the easiest to skip. A material plan finding costs one paragraph to fix; the same flaw caught at code-review costs a rewrite.
+
+Use `base <branch>` for the code pass, not `uncommitted`. `--base` produces the same diff the PR will show, so the reviewer sees exactly what a human will. `uncommitted` drifts from the PR the moment you commit.
+
+## 4. `codex-safe.sh`: strip secrets before invoking an external agent
+
+Any CLI agent you shell out to inherits your environment — including `DATABASE_URL`, `AUTH_SECRET`, API keys loaded from `.env`. An external reviewer does not need them, and you do not want them in that process's context, telemetry, or any prompt it might construct. Wrap the invocation in a script that unsets them:
+
+```bash
+#!/bin/bash
+# codex-safe.sh — strip credentials before invoking an external agent CLI
+set -e
+env \
+  -u DATABASE_URL \
+  -u TEST_DATABASE_URL \
+  -u AUTH_SECRET \
+  -u AUTH_GOOGLE_ID \
+  -u AUTH_GOOGLE_SECRET \
+  -u SENDGRID_API_KEY \
+  -u REDIS_URL \
+  -u OPENROUTER_API_KEY \
+  codex "$@"
+```
+
+Always route the external reviewer through this wrapper rather than calling `codex` directly. The list should mirror every secret-bearing key your `.env` actually defines — audit it whenever you add a new secret.
+
+> **Aside — never paste a live secret into a prompt.** Selecting a `.env` line and dropping it into a Claude prompt sends it to the model and may be retained. If that happens, rotate the credential rather than hoping it wasn't logged. The whole reason `codex-safe.sh` exists is that secrets leak through the seams of agent tooling, not through the front door.
+
+## 5. Subagent scope hygiene (a token-cost guardrail)
+
+A review or exploration subagent with filesystem tools will, left to its own devices, enumerate `node_modules/`, build output, and generated files — burning a large fraction of its budget before doing any useful work. Bake the skip-list into the subagent's prompt; it does not read your `CLAUDE.md` automatically.
+
+One line to paste into any `Explore` / reviewer subagent prompt:
+
+> *Do not read, grep, or enumerate `node_modules/`, build/cache dirs (`.next`, `.docusaurus`, `dist`, `build`), generated files (`src/generated/`, migration snapshot JSON, any `llms-full.txt`), dev-docs scratch dirs, or `*.lock`. If you need evidence from a library internal, cite the one specific file.*
+
+For the in-model fallback reviewer specifically, pass the equivalent as ripgrep globs (`--glob '!node_modules/**'`). The reviewer's job is to verify the diff's load-bearing claims against the code being changed — framework internals matter only when the diff itself cites a specific `file:line`.
+
+## 6. Stop-hook gates that pair with the loops
+
+Two Stop hooks worth adding alongside the review loops, because they catch the "the code is correct but a derived artifact drifted" class that reviewers reading only the diff tend to miss:
+
+- **Derived-doc drift checker** — if MCP-tool / agent docs were edited this session but the aggregated `llms.txt` (or your equivalent generated doc) was not, warn before Stop. Source-of-truth and its generated mirror must move together.
+- **Live integration-test gate by file category** — when files that talk to a real external API are edited (MCP tools, provider clients), remind to run *live* integration tests, not just unit tests. Unit tests on `execute()` mock the API and sail past bugs like a regex that doesn't match the real response shape — the exact failure mode this gate was built for.
+
+Both read the session edit-log written by the `post-tool-use-tracker` hook and exit silently when nothing relevant changed.
+
+---
+
+**Why these aren't in `setup.md`:** every one of them is a lesson learned from a loop that stalled, a secret that nearly leaked, a subagent that spent its budget on `node_modules`, or a reviewer that approved a diff while a generated file silently drifted. They're the difference between review loops that look good in a README and review loops that converge on a real codebase under real failure conditions.

--- a/review-loops.md
+++ b/review-loops.md
@@ -92,6 +92,19 @@ One line to paste into any `Explore` / reviewer subagent prompt:
 
 For the in-model fallback reviewer specifically, pass the equivalent as ripgrep globs (`--glob '!node_modules/**'`). The reviewer's job is to verify the diff's load-bearing claims against the code being changed — framework internals matter only when the diff itself cites a specific `file:line`.
 
+### Match the model tier to the work, not to the task label
+
+`setup.md`'s core principle — *high-volume, low-reasoning search goes to a Haiku subagent; reserve Opus for reasoning that needs the full context* — applies **inside** a review loop too, not just to standalone `Explore` calls. A review pass is rarely one homogeneous lump of "reasoning"; it's a heavy, judgment-light evidence-gathering phase followed by a small, judgment-heavy verdict.
+
+Split it on that seam:
+
+- **Haiku** for anything that reads or grabs a lot of content but barely reasons over it: collecting the diff, enumerating changed files, pulling the surrounding context for each hunk, grepping for every caller of a changed symbol, fetching the issue body and linked files. This is the bulk of the tokens and almost none of the thinking.
+- **Opus (or the main session)** only for the actual verdict: weighing whether a change is correct, classifying finding severity, deciding `MATERIAL_FINDINGS`. This is almost none of the tokens and all of the thinking.
+
+The trap is labeling the whole subagent "code review → must be Opus" and paying Opus rates to scroll through a 2,000-line diff. The *reading* of the diff is Haiku work; only the *judgment* is Opus work. If a subagent's job is overwhelmingly "search through / grab through a lot of content and report back," it's a Haiku subagent — even if it lives inside a loop you think of as high-stakes. Reserve Opus for the call where being wrong actually costs something.
+
+Rule of thumb: before spawning a subagent, ask *"does this need to reason, or just to retrieve?"* Retrieval is Haiku. Only genuine judgment earns Opus.
+
 ## 6. Stop-hook gates that pair with the loops
 
 Two Stop hooks worth adding alongside the review loops, because they catch the "the code is correct but a derived artifact drifted" class that reviewers reading only the diff tend to miss:

--- a/sdlc-standards.md
+++ b/sdlc-standards.md
@@ -1,0 +1,61 @@
+# SDLC Standards Worth Porting to Any Repo
+
+These are repo-level engineering standards from hip-phoenix that change how *an agent* (and a human) should operate — guardrails Claude must respect, single-sources-of-truth it must not bypass, and CI gates it must understand before it touches deploy-adjacent code. They're not a generic DevOps cookbook; each one earns its place because ignoring it produces a class of mistake Claude will otherwise make confidently.
+
+Everything here is verified against the live repo, not aspirational.
+
+## 1. Generated files have one source of truth — never edit the output
+
+Several artifacts in the repo are *generated* from a spec or a shared data file, and editing the generated output directly is always a bug — it gets silently overwritten on the next codegen run, and the spec/output drift apart.
+
+Two instances worth copying as a pattern:
+
+- **API models from a spec.** TypeSpec (`webapp/specifications/`) compiles via `pnpm types:compile` to `webapp/src/generated/`. The `.tsp` is the source; the generated TS is never hand-edited.
+- **Shared constants across languages.** `shared/pricing/tiers.json` is the single source; `scripts/sync-pricing-tiers.mjs` regenerates both a TypeScript file (`webapp/src/lib/pricing-tiers.generated.ts`) and a Python file (`agent-service/src/pricing_tiers.py`). The generated files carry a "do not edit" header. The one fact lives in JSON; both stacks read a typed binding.
+
+**The transferable rule, and how to make Claude obey it:** any file whose content is derived from another file must (a) carry a `// AUTO-GENERATED — DO NOT EDIT. Source: <path>. Regenerate: <command>` header, and (b) be named so the derivation is obvious (`*.generated.ts`). Then add a guardrail skill (`enforcement: "warn"`, see `setup.md` §3) keyed on the generated path or the keyword, so when Claude is about to edit it the hook fires: *"this is generated from X — edit X and run Y instead."* A drift check in CI (`pnpm check` fails if regenerating produces a diff) closes the loop.
+
+This generalizes far beyond pricing: OpenAPI → client SDKs, protobuf → stubs, a design-tokens JSON → CSS vars + a TS theme. The principle is identical — **one editable source, N generated outputs, a header + a guardrail + a CI drift check.**
+
+## 2. The DB migration *is* the deploy gate — understand it before touching schema
+
+hip-phoenix gates production promotion on migrations succeeding, via a deliberately simple mechanism (`.github/workflows/db-migrations.yml`):
+
+1. The workflow triggers on push to `master` filtered by path (`webapp/drizzle/**`, the schema dirs).
+2. Its first action posts a **`pending` GitHub commit status** with a fixed context string (`Vercel - phoenix: Apply DB Migrations`).
+3. Vercel's project is configured to wait on *that exact status string* before promoting the deploy.
+4. On success the status flips to `success` and Vercel promotes; on failure the deploy is blocked.
+
+Two things Claude must internalize when working in a repo like this:
+
+- **The load-bearing identifier is the `context:` string, not the job name.** Renaming the workflow or job is safe; renaming the `context:` silently breaks the gate because the deploy platform is matching on the string. Any agent refactoring CI must treat that string as an API.
+- **Migration triggers can have coverage gaps.** In hip-phoenix the per-PR preview-DB workflow (`neon-pr-branches.yml`) only fires on PR `opened`/`reopened`/`closed` — **not** on subsequent pushes to an already-open PR. So a PR that adds a column in its *second* commit leaves the preview DB on the old schema. Recovery is close+reopen the PR (or run the migrate command manually against the preview DB). The general lesson: **when a migration mysteriously "didn't apply," check the workflow's trigger `types` before assuming the migration itself is broken.**
+
+**Transferable rule:** if schema changes gate deploys, document (a) the exact gate identifier, (b) the trigger paths/events and their gaps, and (c) the manual recovery command — and never use a "push schema directly" command (`db:push`-style) against any deployed environment; only versioned, auditable migrations.
+
+## 3. Decouple validation from deployment — gate the release on a nightly, with an explicit, justified bypass
+
+hip-phoenix merges to `master` continuously but does **not** treat every merge as a production release. The production release workflow (`.github/workflows/release-production.yml`) first runs a `verify-nightly` job that queries the last *scheduled* nightly E2E/smoke run against staging and refuses to proceed unless it passed.
+
+Two design choices worth copying:
+
+- **Nightly validates; release deploys.** Heavy, slow, flaky-prone suites (full E2E, visual, live-integration) run on a schedule against staging, not on every PR. The release gate just reads the latest nightly conclusion. This keeps PR CI fast while keeping production honest.
+- **The bypass is explicit and self-documenting.** There's a `skip_nightly_gate` input "for urgent hotfixes only" that writes a visible note into the run summary when used. The escape hatch exists, but using it leaves a trail. This is the right shape for any gate an agent might be tempted to route around under pressure — make the bypass *possible but loud*, never silent.
+
+**Transferable rule:** separate "is the code healthy?" (scheduled, comprehensive) from "ship it" (on-demand, gated on the latest health signal). Give the gate a bypass that demands a reason and records it.
+
+## 4. Preview-env smoke tests for anything with an HTTP surface
+
+Unit and E2E tests don't catch routing, edge config, env-injection, or auth-redirect bugs that only appear in a real deployment. hip-phoenix's PR template requires a manual preview-env smoke for changes touching REST / MCP / OAuth / webhook surfaces — link the `curl` and its result, backed by an ADR (`webapp/specifications/ards/2026_04_PrEnvironmentTesting.md`).
+
+**Transferable rule:** for HTTP-facing changes, require evidence the surface actually works on a prod-class preview before review — not just that the unit tests pass. Bake the checklist into the PR template so it's not optional. (This pairs with the `/create-pr` + PR-template-enforcement pattern already in `setup.md` — the template is where you encode "what evidence does a reviewer need?")
+
+## 5. Fail fast on the developer's machine, before `dev` even starts
+
+A `predev` hook runs an env-validation script (`scripts/env-check.mjs`) before `pnpm dev`, and a `pnpm doctor` script (`scripts/doctor.mjs`) gives a full environment diagnostic. Missing/invalid env vars surface as a clear message at startup instead of as a confusing runtime crash three screens in.
+
+**Transferable rule:** validate the environment at the earliest possible point (a `predev`/`prestart` hook), and ship a one-command `doctor` that checks tool versions, services, and required secrets. This is high-leverage for both human onboarding and for an agent setting up a fresh worktree — it turns "why won't this boot?" into a named, fixable error. (Complements the worktree-setup notes in `laptop-setup.md`.)
+
+---
+
+**The through-line:** each of these makes an invariant *legible and enforced* rather than relying on everyone (human or agent) to remember it. A generated file announces it's generated and a guardrail stops the edit; a deploy gate names its load-bearing string; a release gate's bypass writes its own justification; an HTTP change must show its smoke test; a broken env fails at `predev`. That legibility is exactly what lets an agent work safely in the repo without having memorized its entire operational history.


### PR DESCRIPTION
## Summary

Adds **`review-loops.md`**, capturing the review-loop and agent-safety patterns hip-phoenix developed *after* the original `setup.md` was written. `setup.md` sketches generic plan/code review loops; this documents what they actually look like once you run them against a real codebase under real failure conditions.

New content:

- **Codex-primary, Opus-fallback reviewer subagents** — pin the external reviewer's model explicitly (`-m gpt-5.5 -c model_reasoning_effort=high`, never inherit local CLI config); fall back to an in-model Opus review on credit exhaustion, auth failure, empty output, *or format-less output*, so the loop never silently stalls or reviews the wrong target.
- **The `MATERIAL_FINDINGS` convergence contract** — severity-gated stop condition (`[critical]/[high]/[major]` flips the gate); the wrapper agent does not re-classify or filter. Mandatory `REVIEWER:` footer line distinguishes the two paths.
- **Three review passes** — plan (before any code), code (`base master`, *not* `uncommitted`, so it matches the eventual PR diff), and post-PR (`pr <URL>`, what a human reviewer sees on GitHub).
- **`codex-safe.sh`** — strip `DATABASE_URL` / `AUTH_SECRET` / API keys from the environment before shelling out to an external agent CLI, plus a note on never pasting live secrets into prompts (rotate if you do).
- **Subagent scope hygiene** — the one-line skip-list that stops review/explore subagents from burning their budget enumerating `node_modules`, build output, and generated files.
- **Stop-hook gates** — derived-doc drift and live integration-test-by-file-category gates that catch the "code is correct but a generated artifact drifted / a real-API regex never matched" class diff-only reviewers miss.

Wires the new doc into `README.md` and `CLAUDE.md`.

## Validation

- Docs-only change; no code or build steps.
- Cross-checked every claim against the live hip-phoenix implementations (`.claude/agents/{plan,code}-reviewer.md`, `.claude/hooks/codex-safe.sh`, `llms-txt-drift-checker.sh`, `mcp-integration-test-gate.sh`).
- Verified no overlap-by-duplication with `setup.md` — this extends it rather than restating it.

## Review Notes

Everything documented is running in hip-phoenix today. No secrets or org-internal hostnames included in the doc.

🤖 Generated with [Claude Code](https://claude.com/claude-code)